### PR TITLE
feat: add workflow modify checker

### DIFF
--- a/.github/workflows/workflow_modify_checker.yml
+++ b/.github/workflows/workflow_modify_checker.yml
@@ -1,0 +1,72 @@
+name: workflow modify checker
+
+# This file is is check the workflow modification on the pull request.
+# If this workflow is set to work, it will forcibly cancel all workflows when any workflow changes are made.
+# To get this workflow working, configure the following settings:
+# 1. Push this file to the default branch.
+# 2. Add issue label 'update CI'.
+# 3. Set github secrets 'CANCEL_WORKFLOW_TOKEN'. (Token can cancel the repository workflow.)
+#
+# If you want to modify any of the workflow files, set the Pull Request label to 'update CI'.
+# Then re-run the canceled workflow.
+
+on: 
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    paths:
+      '.github/workflows/**'
+
+jobs:
+  check-actions:
+    name: check actions
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: check secret
+      id: check_secret
+      run: |
+          if [[ -n '${{secrets.CANCEL_WORKFLOW_TOKEN}}' ]]; then
+            echo "::set-output name=exist_secret::true"
+          else
+            echo "::set-output name=exist_secret::false"
+          fi
+    - if: contains(github.event.pull_request.labels.*.name, 'update CI') != true && steps.check_secret.outputs.exist_secret == 'true'
+      name: wait 20 sec
+      run: sleep 20
+    - if: contains(github.event.pull_request.labels.*.name, 'update CI') != true && steps.check_secret.outputs.exist_secret == 'true'
+      name: cancel workflows
+      id: cancel_workflow
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.CANCEL_WORKFLOW_TOKEN }}
+        script: |
+            const creator = context.payload.sender.login
+            const opts1 = github.actions.listWorkflowRunsForRepo.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'pull_request',
+              status: 'queued'
+            })
+            const queuedWorkflows = await github.paginate(opts1)
+            const opts2 = github.actions.listWorkflowRunsForRepo.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'pull_request',
+              status: 'in_progress'
+            })
+            const inProgressWorkflows = await github.paginate(opts2)
+            const workflows = queuedWorkflows.concat(inProgressWorkflows)
+            //console.log(workflows);
+            for (const workflow of workflows) {
+              if (workflow.run_number == context.runNumber) continue
+              await github.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: workflow.id
+              })
+              console.log(`cancel: ${workflow.name} (${workflow.id}),`,
+                `path:${workflow.head_repository.full_name}/tree/${workflow.head_branch}`);
+            }
+            throw new Error('Change workflow file. please set label "update CI".')
+    - if: success()
+      run: echo "enabled editing workflow."


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- hotfix: add workflow modify checker.
  - To forcibly cancel an illegal workflow with an invalid Pull Request.

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [ ] checked script <!-- npm run check -->
- [x] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
